### PR TITLE
Variable Bug Fixes

### DIFF
--- a/taskt.Commands/Data Commands/DateCalculationCommand.cs
+++ b/taskt.Commands/Data Commands/DateCalculationCommand.cs
@@ -172,11 +172,13 @@ namespace taskt.Commands
                     break;
             }
 
-            string stringDateFormatted = ((object)dateTimeValue).ToString();
+            string stringDateFormatted;
 
             //handle if formatter is required
             if (!string.IsNullOrEmpty(formatting.Trim()))
-                stringDateFormatted = requiredDateTime.ToString(formatting);
+                stringDateFormatted = ((DateTime)dateTimeValue).ToString(formatting);
+            else
+                stringDateFormatted = ((object)dateTimeValue).ToString();
 
             //store string (Result) in variable
             stringDateFormatted.StoreInUserVariable(engine, v_OutputUserVariableName);

--- a/taskt.Commands/DataTable Commands/GetDataRowValueCommand.cs
+++ b/taskt.Commands/DataTable Commands/GetDataRowValueCommand.cs
@@ -65,17 +65,7 @@ namespace taskt.Commands
         {
             var engine = (AutomationEngineInstance)sender;
             var dataRowVariable = v_DataRow.ConvertUserVariableToObject(engine);
-
-            DataRow dataRow;
-            var loopIndexVariable = "Loop.CurrentIndex".ConvertUserVariableToString(engine);
-            //check if currently looping through datatable using BeginListLoopCommand
-            if (dataRowVariable is DataTable && loopIndexVariable != null)
-            {
-                int loopIndex = int.Parse(loopIndexVariable.ToString());
-                dataRow = ((DataTable)dataRowVariable).Rows[loopIndex-1];
-            }
-            else 
-                dataRow = (DataRow)dataRowVariable;
+            DataRow dataRow = (DataRow)dataRowVariable;
 
             var valueIndex = v_DataValueIndex.ConvertUserVariableToString(engine);
             string value = "";

--- a/taskt.Commands/DataTable Commands/UpdateDataRowValueCommand.cs
+++ b/taskt.Commands/DataTable Commands/UpdateDataRowValueCommand.cs
@@ -68,17 +68,7 @@ namespace taskt.Commands
             var dataRowValue = v_DataRowValue.ConvertUserVariableToString(engine);
 
             var dataRowVariable = v_DataRow.ConvertUserVariableToObject(engine);
-
-            DataRow dataRow;
-            var loopIndexVariable = "Loop.CurrentIndex".ConvertUserVariableToString(engine);
-            //check in case of looping through datatable using BeginListLoopCommand
-            if (dataRowVariable is DataTable && loopIndexVariable != null)
-            {
-                int loopIndex = int.Parse(loopIndexVariable.ToString());
-                dataRow = ((DataTable)dataRowVariable).Rows[loopIndex - 1];
-            }
-
-            else dataRow = (DataRow)dataRowVariable;
+            DataRow dataRow = (DataRow)dataRowVariable;
 
             var valueIndex = v_DataValueIndex.ConvertUserVariableToString(engine);
 
@@ -86,7 +76,6 @@ namespace taskt.Commands
             {
                 int index = int.Parse(valueIndex);
                 dataRow[index] = dataRowValue;
-
             }
             else if (v_Option == "Column Name")
             {

--- a/taskt.Commands/Excel Commands/ExcelAppendRowCommand.cs
+++ b/taskt.Commands/Excel Commands/ExcelAppendRowCommand.cs
@@ -69,26 +69,7 @@ namespace taskt.Commands
             }
 
             DataRow row;
-            var loopIndexVariable = "Loop.CurrentIndex".ConvertUserVariableToString(engine);
-            //check in case of looping through datatable using BeginListLoopCommand
-            if (vRow != null && vRow is DataTable && loopIndexVariable != null)
-            {
-                int loopIndex = int.Parse(loopIndexVariable.ToString());
-                row = ((DataTable)vRow).Rows[loopIndex - 1];
-
-                string cellValue;
-                for (int j = 0; j < row.ItemArray.Length; j++)
-                {
-                    if (row.ItemArray[j] == null)
-                        cellValue = string.Empty;
-                    else
-                        cellValue = row.ItemArray[j].ToString();
-
-                    excelSheet.Cells[lastUsedRow + 1, i] = cellValue;
-                    i++;
-                }
-            }
-            else if (vRow != null && vRow is DataRow)
+            if (vRow != null && vRow is DataRow)
             {
                 row = (DataRow)vRow;
 

--- a/taskt.Commands/Excel Commands/ExcelWriteRowCommand.cs
+++ b/taskt.Commands/Excel Commands/ExcelWriteRowCommand.cs
@@ -83,25 +83,7 @@ namespace taskt.Commands
 
             //Write row
             DataRow row;
-            var loopIndexVariable = "Loop.CurrentIndex".ConvertUserVariableToString(engine);
-            //check in case of looping through datatable using BeginListLoopCommand
-            if (vRow != null && vRow is DataTable && loopIndexVariable != null)
-            {
-                int loopIndex = int.Parse(loopIndexVariable.ToString());
-                row = ((DataTable)vRow).Rows[loopIndex - 1];
-
-                string cellValue;
-                for (int j = 0; j < row.ItemArray.Length; j++)
-                {
-                    if (row.ItemArray[j] == null)
-                        cellValue = string.Empty;
-                    else
-                        cellValue = row.ItemArray[j].ToString();
-
-                    excelSheet.Cells[numberOfRow, j + sum] = cellValue;
-                }
-            }
-            else if (vRow != null && vRow is DataRow)
+            if (vRow != null && vRow is DataRow)
             {
                 row = (DataRow)vRow;
 

--- a/taskt.Core/Common/Common.cs
+++ b/taskt.Core/Common/Common.cs
@@ -136,7 +136,6 @@ namespace taskt.Core.Common
             systemVariableList.Add(new ScriptVariable { VariableName = "Env.ActiveWindowTitle", VariableValue = User32Functions.GetActiveWindowTitle() });
             systemVariableList.Add(new ScriptVariable { VariableName = "taskt.EngineContext", VariableValue = "{JsonContext}" });
             systemVariableList.Add(new ScriptVariable { VariableName = "taskt.Location", VariableValue = Assembly.GetEntryAssembly().Location });
-            systemVariableList.Add(new ScriptVariable { VariableName = "Loop.CurrentIndex", VariableValue = "0" });
             return systemVariableList;
         }
 

--- a/taskt.Core/Utilities/CommonUtilities/VariableMethods.cs
+++ b/taskt.Core/Utilities/CommonUtilities/VariableMethods.cs
@@ -15,7 +15,7 @@ namespace taskt.Core.Utilities.CommonUtilities
         /// Replaces variable placeholders ({variable}) with variable text.
         /// </summary>
         /// <param name="sender">The script engine instance (frmScriptEngine) which contains session variables.</param>
-        public static string ConvertUserVariableToString(this string userInputString, IEngine engine)
+        public static string ConvertUserVariableToString(this string userInputString, IEngine engine, bool requiresMarkers = true)
         {
             if (string.IsNullOrEmpty(userInputString))
                 return string.Empty;
@@ -51,7 +51,7 @@ namespace taskt.Core.Utilities.CommonUtilities
             var startVariableMarker = "{";
             var endVariableMarker = "}";
 
-            if (!userInputString.Contains(startVariableMarker) || !userInputString.Contains(endVariableMarker))
+            if ((!userInputString.Contains(startVariableMarker) || !userInputString.Contains(endVariableMarker)) && requiresMarkers)
             {
                 return userInputString.CalculateVariables(engine);
             }
@@ -87,10 +87,24 @@ namespace taskt.Core.Utilities.CommonUtilities
                         {
                             userInputString = userInputString.Replace(searchVariable, (string)varCheck.VariableValue);
                         }
+                        else if (varCheck.VariableValue is List<string> && potentialVariable.Split('.').Length == 2)
+                        {
+                            //get data from a string list using the index
+                            string listIndexString = potentialVariable.Split('.')[1].ConvertUserVariableToString(engine, false);
+                            var list = varCheck.VariableValue as List<string>;
+
+                            string listItem;
+                            if (int.TryParse(listIndexString, out int listIndex))
+                                listItem = list[listIndex].ToString();
+                            else
+                                return userInputString;
+
+                            userInputString = userInputString.Replace(searchVariable, listItem);
+                        }
                         else if (varCheck.VariableValue is DataRow && potentialVariable.Split('.').Length == 2)
                         {
-                            //user is trying to get data from column name/index
-                            string columnName = potentialVariable.Split('.')[1];
+                            //get data from a datarow using the column name/index
+                            string columnName = potentialVariable.Split('.')[1].ConvertUserVariableToString(engine, false);
                             var row = varCheck.VariableValue as DataRow;
 
                             string cellItem;
@@ -103,18 +117,18 @@ namespace taskt.Core.Utilities.CommonUtilities
                         }
                         else if (varCheck.VariableValue is DataTable && potentialVariable.Split('.').Length == 3)
                         {
-                            //user is trying to get data from row index and column name/index	
-                            string rowString = potentialVariable.Split('.')[1];
-                            string columnName = potentialVariable.Split('.')[2];
+                            //get data from datatable using the row index and column name/index	
+                            string rowIndexString = potentialVariable.Split('.')[1].ConvertUserVariableToString(engine, false);
+                            string columnName = potentialVariable.Split('.')[2].ConvertUserVariableToString(engine, false);
                             var dt = varCheck.VariableValue as DataTable;
                             string cellItem;
 
-                            if (int.TryParse(rowString, out int rowNumber))
+                            if (int.TryParse(rowIndexString, out int rowIndex))
                             {                               
                                 if (int.TryParse(columnName, out int columnIndex))
-                                    cellItem = dt.Rows[rowNumber][columnIndex].ToString();
+                                    cellItem = dt.Rows[rowIndex][columnIndex].ToString();
                                 else
-                                    cellItem = dt.Rows[rowNumber][columnName].ToString();
+                                    cellItem = dt.Rows[rowIndex][columnName].ToString();
                             }
                             else
                                 return userInputString;
@@ -122,7 +136,11 @@ namespace taskt.Core.Utilities.CommonUtilities
                             userInputString = userInputString.Replace(searchVariable, cellItem);
                         }
                     }
-                    
+                    else if (!requiresMarkers)
+                    {
+                        if (varCheck.VariableValue is string)
+                            userInputString = userInputString.Replace(potentialVariable, (string)varCheck.VariableValue);
+                    }
                 }                           
             }
             return userInputString.CalculateVariables(engine);

--- a/taskt.Core/Utilities/CommonUtilities/VariableMethods.cs
+++ b/taskt.Core/Utilities/CommonUtilities/VariableMethods.cs
@@ -81,10 +81,31 @@ namespace taskt.Core.Utilities.CommonUtilities
                 {
                     var searchVariable = startVariableMarker + potentialVariable + endVariableMarker;
 
-                    if (userInputString.Contains(searchVariable) && varCheck.VariableValue is string)
+                    if (userInputString.Contains(searchVariable))
                     {
-                        userInputString = userInputString.Replace(searchVariable, (string)varCheck.VariableValue);
+                        if (varCheck.VariableValue is string)
+                        {
+                            userInputString = userInputString.Replace(searchVariable, (string)varCheck.VariableValue);
+                        }
+                        else if (varCheck.VariableValue is DataRow && potentialVariable.Split('.').Length == 2)
+                        {
+                            string columnName = potentialVariable.Split('.')[1];
+                            var row = varCheck.VariableValue as DataRow;
+
+                            string cellItem;
+                            if (int.TryParse(columnName, out var columnIndex))
+                            {
+                                cellItem = row[columnIndex].ToString();
+                            }
+                            else
+                            {
+                                cellItem = row[columnName].ToString();
+                            }
+
+                            userInputString = userInputString.Replace(searchVariable, cellItem);
+                        }
                     }
+                    
                 }                           
             }
             return userInputString.CalculateVariables(engine);

--- a/taskt.Core/Utilities/CommonUtilities/VariableMethods.cs
+++ b/taskt.Core/Utilities/CommonUtilities/VariableMethods.cs
@@ -67,7 +67,7 @@ namespace taskt.Core.Utilities.CommonUtilities
                 string varcheckname = potentialVariable;
                 bool isSystemVar = systemVariables.Any(vars => vars.VariableName == varcheckname);
 
-                if (potentialVariable.Split('.').Length == 2 && !isSystemVar)
+                if (potentialVariable.Split('.').Length >= 2 && !isSystemVar)
                 {
                     varcheckname = potentialVariable.Split('.')[0];
                 }
@@ -89,18 +89,35 @@ namespace taskt.Core.Utilities.CommonUtilities
                         }
                         else if (varCheck.VariableValue is DataRow && potentialVariable.Split('.').Length == 2)
                         {
+                            //user is trying to get data from column name/index
                             string columnName = potentialVariable.Split('.')[1];
                             var row = varCheck.VariableValue as DataRow;
 
                             string cellItem;
                             if (int.TryParse(columnName, out var columnIndex))
-                            {
                                 cellItem = row[columnIndex].ToString();
+                            else
+                                cellItem = row[columnName].ToString();
+
+                            userInputString = userInputString.Replace(searchVariable, cellItem);
+                        }
+                        else if (varCheck.VariableValue is DataTable && potentialVariable.Split('.').Length == 3)
+                        {
+                            //user is trying to get data from row index and column name/index	
+                            string rowString = potentialVariable.Split('.')[1];
+                            string columnName = potentialVariable.Split('.')[2];
+                            var dt = varCheck.VariableValue as DataTable;
+                            string cellItem;
+
+                            if (int.TryParse(rowString, out int rowNumber))
+                            {                               
+                                if (int.TryParse(columnName, out int columnIndex))
+                                    cellItem = dt.Rows[rowNumber][columnIndex].ToString();
+                                else
+                                    cellItem = dt.Rows[rowNumber][columnName].ToString();
                             }
                             else
-                            {
-                                cellItem = row[columnName].ToString();
-                            }
+                                return userInputString;
 
                             userInputString = userInputString.Replace(searchVariable, cellItem);
                         }

--- a/taskt.Studio/Commands/Loop Commands/LoopNumberOfTimesCommand.cs
+++ b/taskt.Studio/Commands/Loop Commands/LoopNumberOfTimesCommand.cs
@@ -49,11 +49,6 @@ namespace taskt.Commands
             LoopNumberOfTimesCommand loopCommand = (LoopNumberOfTimesCommand)parentCommand.ScriptCommand;
             var engine = (AutomationEngineInstance)sender;
 
-            var currentIndex = "Loop.CurrentIndex".ConvertUserVariableToString(engine);
-
-            if (currentIndex == null)
-                "0".StoreInUserVariable(engine, "Loop.CurrentIndex");
-
             int loopTimes;
 
             var loopParameter = loopCommand.v_LoopParameter.ConvertUserVariableToString(engine);
@@ -63,17 +58,12 @@ namespace taskt.Commands
 
             for (int i = startIndex; i < loopTimes; i++)
             {
-
-              //  (i + 1).ToString().StoreInUserVariable(engine, "Loop.CurrentIndex");
-
                 engine.ReportProgress("Starting Loop Number " + (i + 1) + "/" + loopTimes + " From Line " + loopCommand.LineNumber);
 
                 foreach (var cmd in parentCommand.AdditionalScriptCommands)
                 {
                     if (engine.IsCancellationPending)
                         return;
-
-                    (i + 1).ToString().StoreInUserVariable(engine, "Loop.CurrentIndex");
 
                     engine.ExecuteCommand(cmd);
 


### PR DESCRIPTION
Various bug fixes including the addition of a previously existing variable retrieval method.
In the variable clarity PR, the ability to index DataRows like this: {testRow.Column1} was removed. 
It had been put back in and similar methods have been added for DataTables: {testDT.0.2} and List<string>: {testList.0} have been added.