### PR TITLE
Removed Terminal Commands from Default Commands

### DIFF
--- a/OpenBots.Core/Project/Project.cs
+++ b/OpenBots.Core/Project/Project.cs
@@ -27,8 +27,7 @@ namespace OpenBots.Core.Project
             "DataManipulation",
             "Microsoft",
             "SystemAutomation",
-            "UIAutomation",
-            "Terminal"
+            "UIAutomation"
         };
 
         public Project(string projectName)


### PR DESCRIPTION
These commands were added to the default list while they were being developed. I forgot to remove them in the PR. 