### PR TITLE
Var/Arg Binding Fix, Default File Extentions + New Script File Name Validation

### DIFF
--- a/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilder.cs
+++ b/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilder.cs
@@ -578,7 +578,8 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
                 AddCommandToListView(newCommandForm.SelectedCommand);
 
                 _scriptVariables = newCommandForm.ScriptEngineContext.Variables;
-                _scriptArguments = newCommandForm.ScriptEngineContext.Arguments;                
+                _scriptArguments = newCommandForm.ScriptEngineContext.Arguments;
+                uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements);
             }
 
             if (newCommandForm.SelectedCommand.CommandName == "SeleniumElementActionCommand")

--- a/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderListView.cs
+++ b/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderListView.cs
@@ -332,6 +332,7 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
 
                         _scriptVariables = editCommand.ScriptEngineContext.Variables;
                         _scriptArguments = editCommand.ScriptEngineContext.Arguments;
+                        uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements);
                     }
 
                     if (editCommand.SelectedCommand.CommandName == "SeleniumElementActionCommand")

--- a/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderProject.cs
+++ b/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderProject.cs
@@ -731,6 +731,23 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
             {               
                 string newName = "";
                 var newNameForm = new frmInputBox("Enter the name of the new file WITH extension", "New File");
+
+                switch (ScriptProject.ProjectType)
+                {
+                    case ProjectType.OpenBots:
+                        newNameForm.txtInput.Text = ".obscript";
+                        break;
+                    case ProjectType.Python:
+                        newNameForm.txtInput.Text = ".py";
+                        break;
+                    case ProjectType.TagUI:
+                        newNameForm.txtInput.Text = ".tag";
+                        break;
+                    case ProjectType.CSScript:
+                        newNameForm.txtInput.Text = ".cs";
+                        break;
+                }
+
                 newNameForm.ShowDialog();
 
                 if (newNameForm.DialogResult == DialogResult.OK)
@@ -743,6 +760,9 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
                     newNameForm.Dispose();
                     return;
                 }
+
+                if (!Path.HasExtension(newName))
+                    throw new FileFormatException($"No extension provided for '{newName}'");
 
                 string selectedNodePath = tvProject.SelectedNode.Tag.ToString();
                 string newFilePath = Path.Combine(selectedNodePath, newName);
@@ -895,6 +915,9 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
                         newNameForm.Dispose();
                         return;
                     }
+
+                    if (!Path.HasExtension(newName))
+                        throw new FileFormatException($"No extension provided for '{newName}'");
 
                     string newPath = Path.Combine(selectedNodeDirectoryInfo.DirectoryName, newName);
 

--- a/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderUIButtons.cs
+++ b/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderUIButtons.cs
@@ -213,7 +213,7 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
                     _scriptVariables.AddRange(deserializedScript.Variables);
                     _scriptElements.AddRange(deserializedScript.Elements);
                     _scriptArguments.AddRange(deserializedScript.Arguments);
-                    uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements );                  
+                    uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements);                  
 
                     //populate commands
                     PopulateExecutionCommands(deserializedScript.Commands);
@@ -805,6 +805,8 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
             {
                 Invalidate();
                 _scriptVariables = scriptVariableEditor.ScriptVariables;
+                uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements);
+
                 if (!uiScriptTabControl.SelectedTab.Text.Contains(" *"))
                     uiScriptTabControl.SelectedTab.Text += " *"; 
             }
@@ -838,6 +840,8 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
             if (scriptArgumentEditor.ShowDialog() == DialogResult.OK)
             {
                 _scriptArguments = scriptArgumentEditor.ScriptArguments;
+                uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements);
+
                 if (!uiScriptTabControl.SelectedTab.Text.Contains(" *"))
                     uiScriptTabControl.SelectedTab.Text += " *";
             }
@@ -871,6 +875,7 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
             {
                 CreateUndoSnapshot();
                 _scriptElements = scriptElementEditor.ScriptElements;
+                uiScriptTabControl.SelectedTab.Tag = new ScriptObject(_scriptVariables, _scriptArguments, _scriptElements);
             }
 
             scriptElementEditor.Dispose();


### PR DESCRIPTION
- Fixed variable/argument binding issue that caused variables created via a manager to disappear when switching tabs.
- Added default extensions to the new script file creation input form textbox and added validation to check for whether an extension is being provided as it is required. 