### PR TITLE
Fixed frmScriptEngine Memory Leak

### DIFF
--- a/OpenBots.Commands/OpenBots.Commands.Core/OpenBots.Commands.Task/RunTaskCommand.cs
+++ b/OpenBots.Commands/OpenBots.Commands.Core/OpenBots.Commands.Task/RunTaskCommand.cs
@@ -193,7 +193,14 @@ namespace OpenBots.Commands.Task
 				{
 					((Form)parentfrmScriptEngine).TopMost = true;
 				});
-			}          
+			}
+
+			if (_childfrmScriptEngine != null)
+            {
+				((Form)_childfrmScriptEngine).Dispose();
+				_childfrmScriptEngine = null;
+				GC.Collect();
+            }			
 		}
 
 		public override List<Control> Render(IfrmCommandEditor editor, ICommandControls commandControls)

--- a/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderListView.cs
+++ b/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderListView.cs
@@ -414,6 +414,7 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
             {
                 //failed to open sequence command. Dispose and force collection
                 newSequence.Dispose();
+                newSequence = null;
                 GC.Collect();
 
                 //try again
@@ -464,6 +465,7 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
 
             //dispose and force collection
             newSequence.Dispose();
+            newSequence = null;
             GC.Collect();
         }
 

--- a/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderUIButtons.cs
+++ b/OpenBots.Studio/UI/Forms/ScriptBuilder Forms/frmScriptBuilderUIButtons.cs
@@ -1124,7 +1124,11 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
             try
             {
                 if (CurrentEngine != null)
+                {
                     ((Form)CurrentEngine).Close();
+                    ((Form)CurrentEngine).Dispose();
+                    CurrentEngine = null;
+                }
             }
             catch(Exception ex)
             {
@@ -1132,6 +1136,7 @@ namespace OpenBots.UI.Forms.ScriptBuilder_Forms
                 Console.WriteLine(ex);
             }
 
+            GC.Collect();
             //initialize Logger
             switch (_appSettings.EngineSettings.LoggingSinkType)
             {

--- a/OpenBots.Studio/UI/Forms/Sequence Forms/frmSequence.Designer.cs
+++ b/OpenBots.Studio/UI/Forms/Sequence Forms/frmSequence.Designer.cs
@@ -76,6 +76,8 @@ namespace OpenBots.UI.Forms.Sequence_Forms
                 dgvArguments.RowsAdded -= dgvVariablesArguments_RowsAdded;
                 dgvArguments.UserDeletingRow -= dgvVariablesArguments_UserDeletingRow;
                 dgvArguments.KeyDown -= dgvVariablesArguments_KeyDown;
+                lbxImportedNamespaces.KeyDown -= lbxImportedNamespaces_KeyDown;
+                lbxImportedNamespaces.KeyPress -= lbxImportedNamespaces_KeyPress;
 
                 foreach (Control control in Controls)
                     control.Dispose();

--- a/OpenBots.Studio/UI/Forms/Sequence Forms/frmSequence.Designer.cs
+++ b/OpenBots.Studio/UI/Forms/Sequence Forms/frmSequence.Designer.cs
@@ -76,6 +76,10 @@ namespace OpenBots.UI.Forms.Sequence_Forms
                 dgvArguments.RowsAdded -= dgvVariablesArguments_RowsAdded;
                 dgvArguments.UserDeletingRow -= dgvVariablesArguments_UserDeletingRow;
                 dgvArguments.KeyDown -= dgvVariablesArguments_KeyDown;
+
+                foreach (Control control in Controls)
+                    control.Dispose();
+
                 components.Dispose();
             }
             base.Dispose(disposing);

--- a/OpenBots.Studio/UI/Forms/frmScriptEngine.Designer.cs
+++ b/OpenBots.Studio/UI/Forms/frmScriptEngine.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace OpenBots.UI.Forms
+﻿using OpenBots.Utilities;
+using System.Windows.Forms;
+
+namespace OpenBots.UI.Forms
 {
     partial class frmScriptEngine
     {
@@ -15,6 +18,25 @@
         {
             if (disposing && (components != null))
             {
+                lstSteppingCommands.DrawItem -= lstSteppingCommands_DrawItem;
+                lstSteppingCommands.MouseDoubleClick -= lstSteppingCommands_MouseDoubleClick;
+                tmrNotify.Tick -= autoCloseTimer_Tick;
+                uiBtnStepInto.Click -= uiBtnStepInto_Click;
+                uiBtnStepOver.Click -= uiBtnStepOver_Click;
+                uiBtnCancel.Click -= uiBtnCancel_Click;
+                uiBtnPause.Click -= uiBtnPause_Click;
+                pbBotIcon.Click -= pbBotIcon_Click;
+                uiBtnScheduleManagement.Click -= uiBtnScheduleManagement_Click;
+                FormClosing -= frmScriptEngine_FormClosing;
+                Load -= frmProcessingStatus_LoadAsync;
+                GlobalHook.HookStopped -= OnHookStopped;
+                EngineInstance.ReportProgressEvent -= Engine_ReportProgress;
+                EngineInstance.ScriptFinishedEvent -= Engine_ScriptFinishedEvent;
+                EngineInstance.LineNumberChangedEvent -= EngineInstance_LineNumberChangedEvent;
+
+                foreach (Control control in Controls)
+                    control.Dispose();
+
                 components.Dispose();
             }
             base.Dispose(disposing);

--- a/OpenBots.Studio/UI/Forms/frmScriptEngine.cs
+++ b/OpenBots.Studio/UI/Forms/frmScriptEngine.cs
@@ -711,6 +711,7 @@ namespace OpenBots.UI.Forms
         private void autoCloseTimer_Tick(object sender, EventArgs e)
         {
             Close();
+            Dispose();
         }
 
         public delegate void uiBtnCancel_ClickDelegate(object sender, EventArgs e);
@@ -727,7 +728,8 @@ namespace OpenBots.UI.Forms
                 {
                     UpdateLineNumber(0);
                     ClosingAllEngines = true;
-                    Close();                   
+                    Close();
+                    Dispose();
                     return;
                 }
 


### PR DESCRIPTION
Fixed memory leak caused by multiple frmScriptEngine Instances. This leak was detected when running multiple consecutive RunTask commands. 